### PR TITLE
Return Tuple instead of charlist upon error

### DIFF
--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -57,8 +57,8 @@ guess_FQDN() ->
 	{ok, Hostname} = inet:gethostname(),
 	case inet:gethostbyname(Hostname) of 
 		{ok, {hostent, FQDN, _Aliases, inet, _, _Addresses}} -> FQDN;
-		{error, nxdomain} -> "Non-Existent Domain.";
-		{error, _} -> "Error getting DNS Record."
+		{error, nxdomain} -> {error, {nxdomain, "Non-Existent Domain."}};
+		{error, Error} -> {error, {Error, "Error getting DNS Record."}}
 	end.
 
 %% @doc Compute the CRAM digest of `Key' and `Data'


### PR DESCRIPTION
Return Tuple instead of charlist in the event of an error. Upon
success, still return a charlist for backward compatibility.